### PR TITLE
Refactor/tests

### DIFF
--- a/src/Activity.js
+++ b/src/Activity.js
@@ -37,6 +37,7 @@ class Activity {
       })
     })
     friends.push(currentUser)
+    // console.log(friends);
     const result = friends.map(friend => {
       return {
         name: friend.name,

--- a/src/Hydration.js
+++ b/src/Hydration.js
@@ -6,10 +6,10 @@ class Hydration {
     let userHydrationData = this.hydrationData.filter(el => {
       return el.userID === userID
     })
-    return userHydrationData.reduce((acc, el) => {
+    return Number((userHydrationData.reduce((acc, el) => {
       acc += el.numOunces;
       return acc;
-    }, 0) / userHydrationData.length
+    }, 0) / userHydrationData.length).toFixed(1))
   }
 
   waterConsumedForSpecificDay(userID, date) {

--- a/src/Sleep.js
+++ b/src/Sleep.js
@@ -6,10 +6,10 @@ class Sleep {
     let userSleepData = this.sleepData.filter(el => {
       return el.userID === userID;
     })
-    return userSleepData.reduce((acc, el) => {
+    return Number((userSleepData.reduce((acc, el) => {
       acc += el.hoursSlept;
       return acc;
-    }, 0) / userSleepData.length
+    }, 0) / userSleepData.length).toFixed(1))
   }
   averageSleepQualityForUser(userID) {
     let userSleepData = this.sleepData.filter(el => {

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -8,44 +8,46 @@ const userData = require('../data/users-sample.js')
 const fullUserData = require('../data/users.js')
 
 
-describe('Activity', function() {
-
+describe('Activity, using sample dataset', function() {
+  let activity;
+  beforeEach(function() {
+    activity = new Activity(data, userData)
+  })
   it('should be a function', function() {
     expect(Activity).to.be.a('function');
   });
 
   it('should be an instance of Activity', function() {
-    const activity = new Activity();
     expect(activity).to.be.an.instanceof(Activity);
   });
 
   it('should get steps walked for specific day', function() {
-    const activity = new Activity(data, userData);
     expect(activity.getSteps(1, '2019/06/15')).to.equal(3577);
   });
 
   it('should get stairs climbed for specific day', function() {
-    const activity = new Activity(data, userData);
     expect(activity.getStairsClimbed(1, '2019/06/15')).to.equal(16);
   });
 
   it('should get miles walked for specific day', function() {
-    const activity = new Activity(data, userData);
     expect(activity.getMilesWalked(1, '2019/06/15')).to.equal(2.9);
   });
 
   it('should get active minutes for specific day for specific user', function() {
-    const activity = new Activity(data, userData);
     expect(activity.getActiveMinutesForSpecificDay(1, '2019/06/15')).to.equal(140);
+  });
+});
+
+describe('Activity, using full dataset', function() {
+  beforeEach(function() {
+    activity = new Activity(fullData, userData);
   });
 
   it('should get average active minutes for specific week for specific user', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.getAverageActiveMinutesForWeek(1, '2019/09/22')).to.equal(217.7);
   });
 
   it('should get all stats for specific week for specific user', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.getStatsForWeek(1, '2019/09/22')).to.deep.equal([
       [ 11067, 300, 19 ],
   [ 4901, 288, 10 ],
@@ -57,12 +59,10 @@ describe('Activity', function() {
   });
 
   it('should determine whether a user reaches a step goal for a specific day', function() {
-    const activity = new Activity(data, userData);
     expect(activity.reachedStepGoal(3, '2019/06/15')).to.equal(true);
   });
 
   it('should determine which days the user exceeded their step goal', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.findDaysExceededStepGoal(3)).to.deep.equal([
   '2019/06/15', '2019/06/16', '2019/06/19', '2019/06/20',
   '2019/06/21', '2019/06/22', '2019/06/24', '2019/06/27',
@@ -88,17 +88,14 @@ describe('Activity', function() {
   });
 
   it('should determine a user\'s stair climbing record', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.getStairClimbRecord(3)).to.equal(49);
   });
 
   it('should calculate average stats for a given day among all users', function() {
-    const activity = new Activity(data, userData);
-    expect(activity.getAverageUserStats('2019/06/15')).to.deep.equal([ 20.8, 6026.6, 144.2 ]);
+    expect(activity.getAverageUserStats('2019/06/15')).to.deep.equal([23.88, 8386.16, 155.62]);
   });
 
   it('should rank the user among his or her friends for last seven days of steps', function() {
-    const activity = new Activity(fullData, fullUserData);
     expect(activity.getFriendsLeaderboard(1, '2019/09/15')).to.deep.equal([
   { name: 'Luisa Hane', numSteps: 64610 },
   { name: 'Garnett Cruickshank', numSteps: 63268 },
@@ -108,7 +105,6 @@ describe('Activity', function() {
   });
 
   it('should calculate trends of three or more days of increasing steps', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.getTrend(1, '2019/09/15')).to.deep.equal([
   { date: new Date('2019/09/12'), numSteps: 13684 },
   { date: new Date('2019/09/11'), numSteps: 10350 },
@@ -117,7 +113,6 @@ describe('Activity', function() {
   });
 
   it('should find consecutive days when the user met their goal', function() {
-    const activity = new Activity(fullData, userData);
     expect(activity.findConsecutiveDaysReachedGoal(1, '2019/09/15')).to.deep.equal([
   { date: new Date('2019/09/12'), numSteps: 13684, goal: 10000 },
   { date: new Date('2019/09/11'), numSteps: 13684, goal: 10000 },

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -4,120 +4,123 @@ const expect = chai.expect;
 const Activity = require('../src/Activity')
 const data = require('../data/activity-sample.js');
 const fullData = require('../data/activity.js');
-const userData = require('../data/users-sample.js')
-const fullUserData = require('../data/users.js')
+const userData = require('../data/users-sample.js');
+const fullUserData = require('../data/users.js');
+let activity;
 
+describe('Activity', function() {
 
-describe('Activity, using sample dataset', function() {
-  let activity;
-  beforeEach(function() {
-    activity = new Activity(data, userData)
+  describe('using sample dataset', function() {
+    beforeEach(function() {
+      activity = new Activity(data, userData)
+    });
+
+    it('should be a function', function() {
+      expect(Activity).to.be.a('function');
+    });
+
+    it('should be an instance of Activity', function() {
+      expect(activity).to.be.an.instanceof(Activity);
+    });
+
+    it('should get steps walked for specific day', function() {
+      expect(activity.getSteps(1, '2019/06/15')).to.equal(3577);
+    });
+
+    it('should get stairs climbed for specific day', function() {
+      expect(activity.getStairsClimbed(1, '2019/06/15')).to.equal(16);
+    });
+
+    it('should get miles walked for specific day', function() {
+      expect(activity.getMilesWalked(1, '2019/06/15')).to.equal(2.9);
+    });
+
+    it('should get active minutes for specific day for specific user', function() {
+      expect(activity.getActiveMinutesForSpecificDay(1, '2019/06/15')).to.equal(140);
+    });
+  });
+
+  describe('using full dataset', function() {
+    beforeEach(function() {
+      activity = new Activity(fullData, userData);
+    });
+
+    it('should get average active minutes for specific week for specific user', function() {
+      expect(activity.getAverageActiveMinutesForWeek(1, '2019/09/22')).to.equal(217.7);
+    });
+
+    it('should get all stats for specific week for specific user', function() {
+      expect(activity.getStatsForWeek(1, '2019/09/22')).to.deep.equal([
+        [ 11067, 300, 19 ],
+    [ 4901, 288, 10 ],
+    [ 9974, 80, 40 ],
+    [ 12083, 218, 20 ],
+    [ 14000, 262, 17 ],
+    [ 5711, 137, 43 ],
+    [ 8072, 239, 23 ]]);
+    });
+
+    it('should determine whether a user reaches a step goal for a specific day', function() {
+      expect(activity.reachedStepGoal(3, '2019/06/15')).to.equal(true);
+    });
+
+    it('should determine which days the user exceeded their step goal', function() {
+      expect(activity.findDaysExceededStepGoal(3)).to.deep.equal([
+    '2019/06/15', '2019/06/16', '2019/06/19', '2019/06/20',
+    '2019/06/21', '2019/06/22', '2019/06/24', '2019/06/27',
+    '2019/06/28', '2019/06/29', '2019/07/01', '2019/07/03',
+    '2019/07/04', '2019/07/05', '2019/07/06', '2019/07/08',
+    '2019/07/09', '2019/07/10', '2019/07/11', '2019/07/12',
+    '2019/07/13', '2019/07/14', '2019/07/16', '2019/07/17',
+    '2019/07/18', '2019/07/19', '2019/07/20', '2019/07/21',
+    '2019/07/22', '2019/07/23', '2019/07/24', '2019/07/25',
+    '2019/07/26', '2019/07/28', '2019/07/29', '2019/07/31',
+    '2019/08/01', '2019/08/02', '2019/08/03', '2019/08/04',
+    '2019/08/06', '2019/08/07', '2019/08/09', '2019/08/10',
+    '2019/08/11', '2019/08/12', '2019/08/13', '2019/08/14',
+    '2019/08/16', '2019/08/17', '2019/08/18', '2019/08/20',
+    '2019/08/21', '2019/08/22', '2019/08/23', '2019/08/27',
+    '2019/08/28', '2019/08/29', '2019/08/30', '2019/08/31',
+    '2019/09/01', '2019/09/02', '2019/09/03', '2019/09/04',
+    '2019/09/05', '2019/09/06', '2019/09/07', '2019/09/08',
+    '2019/09/09', '2019/09/11', '2019/09/12', '2019/09/13',
+    '2019/09/14', '2019/09/15', '2019/09/16', '2019/09/18',
+    '2019/09/19', '2019/09/20', '2019/09/21'
+  ]);
+    });
+
+    it('should determine a user\'s stair climbing record', function() {
+      expect(activity.getStairClimbRecord(3)).to.equal(49);
+    });
+
+    it('should calculate average stats for a given day among all users', function() {
+      expect(activity.getAverageUserStats('2019/06/15')).to.deep.equal([23.88, 8386.16, 155.62]);
+    });
+
+    it('should rank the user among his or her friends for last seven days of steps', function() {
+      expect(activity.getFriendsLeaderboard(1, '2019/09/15')).to.deep.equal([
+    { name: 'Luisa Hane', numSteps: 64610 },
+    { name: 'Garnett Cruickshank', numSteps: 63268 },
+    { name: 'Mae Connelly', numSteps: 55162 },
+    { name: 'Laney Abshire', numSteps: 53324 }
+  ]);
+    });
+
+    it('should calculate trends of three or more days of increasing steps', function() {
+      expect(activity.getTrend(1, '2019/09/15')).to.deep.equal([
+    { date: new Date('2019/09/12'), numSteps: 13684 },
+    { date: new Date('2019/09/11'), numSteps: 10350 },
+    { date: new Date('2019/09/10'), numSteps: 5938 }
+  ]);
+    });
+
+    it('should find consecutive days when the user met their goal', function() {
+      expect(activity.findConsecutiveDaysReachedGoal(1, '2019/09/15')).to.deep.equal([
+    { date: new Date('2019/09/12'), numSteps: 13684, goal: 10000 },
+    { date: new Date('2019/09/11'), numSteps: 13684, goal: 10000 },
+    { date: new Date('2019/09/10'), numSteps: 10350, goal: 10000 }
+  ]);
+    });
+
   })
-  it('should be a function', function() {
-    expect(Activity).to.be.a('function');
-  });
-
-  it('should be an instance of Activity', function() {
-    expect(activity).to.be.an.instanceof(Activity);
-  });
-
-  it('should get steps walked for specific day', function() {
-    expect(activity.getSteps(1, '2019/06/15')).to.equal(3577);
-  });
-
-  it('should get stairs climbed for specific day', function() {
-    expect(activity.getStairsClimbed(1, '2019/06/15')).to.equal(16);
-  });
-
-  it('should get miles walked for specific day', function() {
-    expect(activity.getMilesWalked(1, '2019/06/15')).to.equal(2.9);
-  });
-
-  it('should get active minutes for specific day for specific user', function() {
-    expect(activity.getActiveMinutesForSpecificDay(1, '2019/06/15')).to.equal(140);
-  });
 });
-
-describe('Activity, using full dataset', function() {
-  beforeEach(function() {
-    activity = new Activity(fullData, userData);
-  });
-
-  it('should get average active minutes for specific week for specific user', function() {
-    expect(activity.getAverageActiveMinutesForWeek(1, '2019/09/22')).to.equal(217.7);
-  });
-
-  it('should get all stats for specific week for specific user', function() {
-    expect(activity.getStatsForWeek(1, '2019/09/22')).to.deep.equal([
-      [ 11067, 300, 19 ],
-  [ 4901, 288, 10 ],
-  [ 9974, 80, 40 ],
-  [ 12083, 218, 20 ],
-  [ 14000, 262, 17 ],
-  [ 5711, 137, 43 ],
-  [ 8072, 239, 23 ]]);
-  });
-
-  it('should determine whether a user reaches a step goal for a specific day', function() {
-    expect(activity.reachedStepGoal(3, '2019/06/15')).to.equal(true);
-  });
-
-  it('should determine which days the user exceeded their step goal', function() {
-    expect(activity.findDaysExceededStepGoal(3)).to.deep.equal([
-  '2019/06/15', '2019/06/16', '2019/06/19', '2019/06/20',
-  '2019/06/21', '2019/06/22', '2019/06/24', '2019/06/27',
-  '2019/06/28', '2019/06/29', '2019/07/01', '2019/07/03',
-  '2019/07/04', '2019/07/05', '2019/07/06', '2019/07/08',
-  '2019/07/09', '2019/07/10', '2019/07/11', '2019/07/12',
-  '2019/07/13', '2019/07/14', '2019/07/16', '2019/07/17',
-  '2019/07/18', '2019/07/19', '2019/07/20', '2019/07/21',
-  '2019/07/22', '2019/07/23', '2019/07/24', '2019/07/25',
-  '2019/07/26', '2019/07/28', '2019/07/29', '2019/07/31',
-  '2019/08/01', '2019/08/02', '2019/08/03', '2019/08/04',
-  '2019/08/06', '2019/08/07', '2019/08/09', '2019/08/10',
-  '2019/08/11', '2019/08/12', '2019/08/13', '2019/08/14',
-  '2019/08/16', '2019/08/17', '2019/08/18', '2019/08/20',
-  '2019/08/21', '2019/08/22', '2019/08/23', '2019/08/27',
-  '2019/08/28', '2019/08/29', '2019/08/30', '2019/08/31',
-  '2019/09/01', '2019/09/02', '2019/09/03', '2019/09/04',
-  '2019/09/05', '2019/09/06', '2019/09/07', '2019/09/08',
-  '2019/09/09', '2019/09/11', '2019/09/12', '2019/09/13',
-  '2019/09/14', '2019/09/15', '2019/09/16', '2019/09/18',
-  '2019/09/19', '2019/09/20', '2019/09/21'
-]);
-  });
-
-  it('should determine a user\'s stair climbing record', function() {
-    expect(activity.getStairClimbRecord(3)).to.equal(49);
-  });
-
-  it('should calculate average stats for a given day among all users', function() {
-    expect(activity.getAverageUserStats('2019/06/15')).to.deep.equal([23.88, 8386.16, 155.62]);
-  });
-
-  it('should rank the user among his or her friends for last seven days of steps', function() {
-    expect(activity.getFriendsLeaderboard(1, '2019/09/15')).to.deep.equal([
-  { name: 'Luisa Hane', numSteps: 64610 },
-  { name: 'Garnett Cruickshank', numSteps: 63268 },
-  { name: 'Mae Connelly', numSteps: 55162 },
-  { name: 'Laney Abshire', numSteps: 53324 }
-]);
-  });
-
-  it('should calculate trends of three or more days of increasing steps', function() {
-    expect(activity.getTrend(1, '2019/09/15')).to.deep.equal([
-  { date: new Date('2019/09/12'), numSteps: 13684 },
-  { date: new Date('2019/09/11'), numSteps: 10350 },
-  { date: new Date('2019/09/10'), numSteps: 5938 }
-]);
-  });
-
-  it('should find consecutive days when the user met their goal', function() {
-    expect(activity.findConsecutiveDaysReachedGoal(1, '2019/09/15')).to.deep.equal([
-  { date: new Date('2019/09/12'), numSteps: 13684, goal: 10000 },
-  { date: new Date('2019/09/11'), numSteps: 13684, goal: 10000 },
-  { date: new Date('2019/09/10'), numSteps: 10350, goal: 10000 }
-]);
-  });
-
-})

--- a/test/Hydration-test.js
+++ b/test/Hydration-test.js
@@ -4,30 +4,30 @@ const expect = chai.expect;
 const Hydration = require('../src/Hydration')
 const data = require('../data/hydration-sample.js');
 const fullData = require('../data/hydration.js');
+let hydration;
 
 describe('Hydration', function() {
+  beforeEach(function() {
+    hydration = new Hydration(fullData);
+  });
 
   it('should be a function', function() {
     expect(Hydration).to.be.a('function');
   });
 
   it('should be an instance of Hydration', function() {
-    const hydration = new Hydration();
     expect(hydration).to.be.an.instanceof(Hydration);
   });
 
   it('should calculate average water consumed per day', function() {
-    const hydration = new Hydration(data);
-    expect(hydration.averageWaterConsumedPerDay(1)).to.equal(39.5);
+    expect(hydration.averageWaterConsumedPerDay(1)).to.equal(58.3);
   })
 
   it('should show water consumed for a specific day', function() {
-    const hydration = new Hydration(data);
-    expect(hydration.waterConsumedForSpecificDay(1, '2019/06/16')).to.equal(42);
+    expect(hydration.waterConsumedForSpecificDay(1, '2019/06/16')).to.equal(69);
   })
 
   it('should show water consumed each day for specified last seven days', function() {
-    const hydration = new Hydration(fullData);
     expect(hydration.waterConsumedForSpecificWeek(3, '2019/09/18')).to.deep.equal([32, 69, 22, 58, 87, 38, 64]);
   })
 

--- a/test/Sleep-test.js
+++ b/test/Sleep-test.js
@@ -2,48 +2,47 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const Sleep = require('../src/Sleep')
-const data = require('../data/sleep-sample.js');
-const fullData = require('../data/sleep.js');
+const data = require('../data/sleep.js');
 
 describe('Sleep', function() {
+
+  beforeEach(function() {
+    const sleep = new Sleep(data);
 
   it('should be a function', function() {
     expect(Sleep).to.be.a('function');
   });
 
   it('should be an instance of Sleep', function() {
-    const sleep = new Sleep();
     expect(sleep).to.be.an.instanceof(Sleep);
   });
 
   it('should calculate average hours of sleep', function() {
-    const sleep = new Sleep(data);
+    expect(sleep.averageHoursSleptPerDay(1)).to.equal(5.1);
+  });
+  
+  it('should calculate average hours of sleep', function() {
     expect(sleep.averageHoursSleptPerDay(1)).to.equal(5.1);
   });
 
   it('should return hours slept for a specific day', function() {
-    const sleep = new Sleep(data);
     expect(sleep.getHoursSlept(3,"2019/06/15")).to.equal(10.8)
     expect(sleep.getHoursSlept(2,"2019/06/15")).to.equal(7)
   });
 
   it('should find the hours slept for a specific week', function() {
-    const sleep = new Sleep(fullData);
     expect(sleep.hoursSleptForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 9.3, 9.2, 9.5, 7.5, 5.1, 11, 6 ])
   });
 
   it('should return a user\'s sleep quality for a specific week', function() {
-    const sleep = new Sleep(fullData);
     expect(sleep.sleepQualityForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 4, 4.8, 4.7, 4.6, 1.4, 1.7, 3.2 ])
   });
 
   it('should calculate average sleep quality for a user', function() {
-    const sleep = new Sleep(data);
     expect(sleep.averageSleepQualityForUser(1)).to.equal(2.9)
   });
 
   it('should find good sleepers for a specific week', function() {
-    const sleep = new Sleep(fullData);
     expect(sleep.findGoodSleepers("2019/09/22")).to.deep.equal([
   { userID: 5, averageSleepQuality: 3.5 },
   { userID: 8, averageSleepQuality: 3.2 },
@@ -71,7 +70,6 @@ describe('Sleep', function() {
   });
 
   it('should find the longest sleepers for a given day', function() {
-    const sleep = new Sleep(fullData);
     expect(sleep.findLongestSleepers("2019/09/22")).to.deep.equal([
     {
       userID: 7,
@@ -89,8 +87,9 @@ describe('Sleep', function() {
   });
 
   it('should return sleep quality for a given day', function() {
-    const sleep = new Sleep(data);
     expect(sleep.getSleepQuality(1, "2019/06/15")).to.equal(2.2);
   });
+
+});
 
 });

--- a/test/Sleep-test.js
+++ b/test/Sleep-test.js
@@ -4,12 +4,12 @@ const expect = chai.expect;
 const Sleep = require('../src/Sleep')
 const data = require('../data/sleep.js');
 const sampleData = require('../data/sleep-sample.js');
+let sleep;
 
 describe('Sleep', function() {
-  let sleep;
   beforeEach(function() {
     sleep = new Sleep(data);
-  })
+  });
 
   it('should be a function', function() {
     expect(Sleep).to.be.a('function');
@@ -27,7 +27,7 @@ describe('Sleep', function() {
       {userID: 3, date: '2019/06/15', hoursSlept: 10.8, sleepQuality: 4.7},
       {userID: 4, date: '2019/06/15', hoursSlept: 5.4, sleepQuality: 3},
       {userID: 1, date: '2019/06/15', hoursSlept: 4.1, sleepQuality: 3.6}
-    ])
+    ]);
   });
 
   it('should calculate the overall average hours of sleep for a user', function() {
@@ -35,23 +35,23 @@ describe('Sleep', function() {
   });
 
   it('should calculate the overall average sleep quality for a user', function() {
-    expect(sleep.averageSleepQualityForUser(1)).to.equal(3)
+    expect(sleep.averageSleepQualityForUser(1)).to.equal(3);
   });
 
   it('should return hours slept for a specific day', function() {
-    expect(sleep.getHoursSlept(3,"2019/06/15")).to.equal(10.8)
+    expect(sleep.getHoursSlept(3,"2019/06/15")).to.equal(10.8);
   });
 
   it('should return hours slept for a specific day for different users', function() {
-    expect(sleep.getHoursSlept(2,"2019/06/15")).to.equal(7)
+    expect(sleep.getHoursSlept(2,"2019/06/15")).to.equal(7);
   });
 
   it('should find the hours slept for a specific week', function() {
-    expect(sleep.hoursSleptForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 9.3, 9.2, 9.5, 7.5, 5.1, 11, 6 ])
+    expect(sleep.hoursSleptForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 9.3, 9.2, 9.5, 7.5, 5.1, 11, 6 ]);
   });
 
   it('should return a user\'s sleep quality for a specific week', function() {
-    expect(sleep.sleepQualityForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 4, 4.8, 4.7, 4.6, 1.4, 1.7, 3.2 ])
+    expect(sleep.sleepQualityForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 4, 4.8, 4.7, 4.6, 1.4, 1.7, 3.2 ]);
   });
 
   it('should find good sleepers for a specific week', function() {
@@ -78,7 +78,7 @@ describe('Sleep', function() {
   { userID: 48, averageSleepQuality: 3.7 },
   { userID: 49, averageSleepQuality: 3.1 },
   { userID: 50, averageSleepQuality: 3.6 }
-])
+]);
   });
 
   it('should find the longest sleepers for a given day', function() {
@@ -95,7 +95,7 @@ describe('Sleep', function() {
       hoursSlept: 10.9,
       sleepQuality: 3.8
     }
-    ])
+  ]);
   });
 
   it('should return sleep quality for a given day', function() {

--- a/test/Sleep-test.js
+++ b/test/Sleep-test.js
@@ -3,11 +3,13 @@ const expect = chai.expect;
 
 const Sleep = require('../src/Sleep')
 const data = require('../data/sleep.js');
+const sampleData = require('../data/sleep-sample.js');
 
 describe('Sleep', function() {
-
+  let sleep;
   beforeEach(function() {
-    const sleep = new Sleep(data);
+    sleep = new Sleep(data);
+  })
 
   it('should be a function', function() {
     expect(Sleep).to.be.a('function');
@@ -17,16 +19,30 @@ describe('Sleep', function() {
     expect(sleep).to.be.an.instanceof(Sleep);
   });
 
-  it('should calculate average hours of sleep', function() {
-    expect(sleep.averageHoursSleptPerDay(1)).to.equal(5.1);
+  it('should instantiate with data by default', function() {
+    sleep = new Sleep(sampleData);
+    expect(sleep.sleepData).to.deep.equal([
+      {userID: 1, date: '2019/06/15', hoursSlept: 6.1, sleepQuality: 2.2},
+      {userID: 2, date: '2019/06/15', hoursSlept: 7, sleepQuality: 4.7},
+      {userID: 3, date: '2019/06/15', hoursSlept: 10.8, sleepQuality: 4.7},
+      {userID: 4, date: '2019/06/15', hoursSlept: 5.4, sleepQuality: 3},
+      {userID: 1, date: '2019/06/15', hoursSlept: 4.1, sleepQuality: 3.6}
+    ])
   });
-  
-  it('should calculate average hours of sleep', function() {
-    expect(sleep.averageHoursSleptPerDay(1)).to.equal(5.1);
+
+  it('should calculate the overall average hours of sleep for a user', function() {
+    expect(sleep.averageHoursSleptPerDay(1)).to.equal(7.7);
+  });
+
+  it('should calculate the overall average sleep quality for a user', function() {
+    expect(sleep.averageSleepQualityForUser(1)).to.equal(3)
   });
 
   it('should return hours slept for a specific day', function() {
     expect(sleep.getHoursSlept(3,"2019/06/15")).to.equal(10.8)
+  });
+
+  it('should return hours slept for a specific day for different users', function() {
     expect(sleep.getHoursSlept(2,"2019/06/15")).to.equal(7)
   });
 
@@ -36,10 +52,6 @@ describe('Sleep', function() {
 
   it('should return a user\'s sleep quality for a specific week', function() {
     expect(sleep.sleepQualityForSpecificWeek(22,"2019/09/22")).to.deep.equal([ 4, 4.8, 4.7, 4.6, 1.4, 1.7, 3.2 ])
-  });
-
-  it('should calculate average sleep quality for a user', function() {
-    expect(sleep.averageSleepQualityForUser(1)).to.equal(2.9)
   });
 
   it('should find good sleepers for a specific week', function() {
@@ -89,7 +101,5 @@ describe('Sleep', function() {
   it('should return sleep quality for a given day', function() {
     expect(sleep.getSleepQuality(1, "2019/06/15")).to.equal(2.2);
   });
-
-});
 
 });

--- a/test/User-test.js
+++ b/test/User-test.js
@@ -3,20 +3,23 @@ const expect = chai.expect;
 
 const User = require('../src/User')
 const data = require('../data/users-sample.js');
+let user;
 
 describe('User', function() {
+
+  beforeEach(function() {
+    user = new User(data[0]);
+  });
 
   it('should be a function', function() {
     expect(User).to.be.a('function');
   });
 
   it('should be an instance of User', function() {
-    const user = new User(data[0]);
     expect(user).to.be.an.instanceof(User);
   });
 
   it('should create a user and populate data', function() {
-    const user = new User(data[0]);
     expect(user.id).to.equal(1);
     expect(user.name).to.equal('Luisa Hane');
     expect(user.address).to.equal('15195 Nakia Tunnel, Erdmanport VA 19901-1697');
@@ -27,7 +30,6 @@ describe('User', function() {
   });
 
   it('should return the user\'s first name', function() {
-    const user = new User(data[0]);
     expect(user.returnFirstName()).to.equal('Luisa');
   });
 

--- a/test/User-test.js
+++ b/test/User-test.js
@@ -6,7 +6,6 @@ const data = require('../data/users-sample.js');
 let user;
 
 describe('User', function() {
-
   beforeEach(function() {
     user = new User(data[0]);
   });

--- a/test/UserRepository-test.js
+++ b/test/UserRepository-test.js
@@ -3,27 +3,27 @@ const expect = chai.expect;
 
 const UserRepository = require('../src/UserRepository')
 const data = require('../data/users-sample.js');
-
+let userRepository;
 
 describe('UserRepository', function() {
+  beforeEach(function() {
+    userRepository = new UserRepository(data);
+  });
 
   it('should be a function', function() {
     expect(UserRepository).to.be.a('function');
   });
 
   it('should be an instance of UserRepository', function() {
-    const userRepository = new UserRepository();
     expect(userRepository).to.be.an.instanceof(UserRepository);
   });
 
   it('should store data', function() {
-    const userRepository = new UserRepository(data);
     expect(userRepository.data).to.equal(data);
   });
 
   it('should calculate average daily step goal', function() {
-    const userRepository = new UserRepository(data);
     expect(userRepository.getAverageStepGoal()).to.equal(6400);
-  })
+  });
 
 });


### PR DESCRIPTION
# Description

This PR refactors the test files to use `beforeEach()` hooks and a few nested `describe` blocks to separate out tests that use sample datasets vs full datasets.

## Type of change

- [x] Refactor
